### PR TITLE
make OTel endpoint optional and use defaults if note set

### DIFF
--- a/cobrautil.go
+++ b/cobrautil.go
@@ -157,7 +157,7 @@ func RegisterOpenTelemetryFlags(flags *pflag.FlagSet, flagPrefix, serviceName st
 	prefixed := prefixJoiner(stringz.DefaultEmpty(flagPrefix, "otel"))
 
 	flags.String(prefixed("provider"), "none", `OpenTelemetry provider for tracing ("none", "jaeger, otlphttp", "otlpgrpc")`)
-	flags.String(prefixed("endpoint"), "", "OpenTelemetry collector endpoint")
+	flags.String(prefixed("endpoint"), "", "OpenTelemetry collector endpoint - the endpoint can also be set by using enviroment variables")
 	flags.String(prefixed("service-name"), serviceName, "service name for trace data")
 	flags.String(prefixed("trace-propagator"), "w3c", `OpenTelemetry trace propagation format ("b3", "w3c", "ottrace"). Add multiple propagators separated by comma.`)
 }

--- a/cobrautil.go
+++ b/cobrautil.go
@@ -190,31 +190,34 @@ func OpenTelemetryRunE(flagPrefix string, prerunLevel zerolog.Level) CobraRunFun
 		case "none":
 			// Nothing.
 		case "jaeger":
+			var opts []jaeger.CollectorEndpointOption
 			if endpoint != "" {
-				exporter, err = jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(endpoint)))
-			} else {
-				exporter, err = jaeger.New(jaeger.WithCollectorEndpoint())
+				opts = append(opts, jaeger.WithEndpoint(endpoint))
 			}
+
+			exporter, err = jaeger.New(jaeger.WithCollectorEndpoint(opts...))
 			if err != nil {
 				return err
 			}
 			return initOtelTracer(exporter, serviceName, propagators)
 		case "otlphttp":
+			var opts []otlptracehttp.Option
 			if endpoint != "" {
-				exporter, err = otlptrace.New(context.Background(), otlptracehttp.NewClient(otlptracehttp.WithEndpoint(endpoint)))
-			} else {
-				exporter, err = otlptrace.New(context.Background(), otlptracehttp.NewClient())
+				opts = append(opts, otlptracehttp.WithEndpoint(endpoint))
 			}
+
+			exporter, err = otlptrace.New(context.Background(), otlptracehttp.NewClient(opts...))
 			if err != nil {
 				return err
 			}
 			return initOtelTracer(exporter, serviceName, propagators)
 		case "otlpgrpc":
+			var opts []otlptracegrpc.Option
 			if endpoint != "" {
-				exporter, err = otlptrace.New(context.Background(), otlptracegrpc.NewClient(otlptracegrpc.WithEndpoint(endpoint)))
-			} else {
-				exporter, err = otlptrace.New(context.Background(), otlptracegrpc.NewClient())
+				opts = append(opts, otlptracegrpc.WithEndpoint(endpoint))
 			}
+
+			exporter, err = otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
 			if err != nil {
 				return err
 			}

--- a/cobrautil.go
+++ b/cobrautil.go
@@ -176,7 +176,7 @@ func OpenTelemetryRunE(flagPrefix string, prerunLevel zerolog.Level) CobraRunFun
 
 		provider := strings.ToLower(MustGetString(cmd, prefixed("provider")))
 		serviceName := MustGetString(cmd, prefixed("service-name"))
-		endpoint, _ := cmd.Flags().GetString(prefixed("endpoint"))
+		endpoint := MustGetString(cmd, prefixed("endpoint"))
 		propagators := strings.Split(MustGetString(cmd, prefixed("trace-propagator")), ",")
 
 		var exporter trace.SpanExporter

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
+	go.opentelemetry.io/contrib/propagators/b3 v1.3.0
+	go.opentelemetry.io/contrib/propagators/ot v1.3.0
 	go.opentelemetry.io/otel v1.3.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.3.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,10 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opentelemetry.io/contrib/propagators/b3 v1.3.0 h1:f+JfMSDNm2u+fekYYjyoixk+DWDTDAGD3SC50y61koE=
+go.opentelemetry.io/contrib/propagators/b3 v1.3.0/go.mod h1:qzi0km8qO3l2jxB5aDg4Q9xyqV4HKnCWZYpVYDTUIT0=
+go.opentelemetry.io/contrib/propagators/ot v1.3.0 h1:hqFpnicJXKy8l8PfwFWhRSt/TgOHCpugKiXsPP1zJUc=
+go.opentelemetry.io/contrib/propagators/ot v1.3.0/go.mod h1:Gpwe4R8j9Zbw7aaADYSQRE1U0o41j0TwnHxuhwRLklk=
 go.opentelemetry.io/otel v1.3.0 h1:APxLf0eiBwLl+SOXiJJCVYzA1OOJNyAoV8C5RNRyy7Y=
 go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
 go.opentelemetry.io/otel/exporters/jaeger v1.3.0 h1:HfydzioALdtcB26H5WHc4K47iTETJCdloL7VN579/L0=


### PR DESCRIPTION
## What

This change makes specifying an `otel-endpoint` optional. If not set, the OpenTelemetry exporters will be configured through:

- The OpenTelementry environment variables, if set
- The OpenTelemetry specification defaults

See https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp/otlptrace#environment-variables and https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/jaeger#environment-variables for the defaults

## Why

Setting the client with `WithEndpoint` forces the client to [use the default URL Path](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#WithEndpoint). By making setting the endpoint via command line flag optional, we can unify the `jaeger` and `otlp*` provider command line flags, and still give the option of custom configurations via environment variables. 

The alternative would be to add another flag for `URLPath`.

/cc https://github.com/authzed/spicedb/issues/14
/cc @christroger 