### PR TITLE
Update OtelTracer respect ENV variables

### DIFF
--- a/cobrautil.go
+++ b/cobrautil.go
@@ -232,10 +232,7 @@ func OpenTelemetryRunE(flagPrefix string, prerunLevel zerolog.Level) CobraRunFun
 }
 
 func initOtelTracer(exporter trace.SpanExporter, serviceName string, propagators []string) error {
-	res, _ := resource.Merge(
-		resource.Default(),
-		resource.NewSchemaless(semconv.ServiceNameKey.String(serviceName)),
-	)
+	res, _ := resource.New(context.Background(), resource.WithAttributes(semconv.ServiceNameKey.String(serviceName)))
 
 	tp := trace.NewTracerProvider(
 		trace.WithSampler(trace.AlwaysSample()),


### PR DESCRIPTION
Hi 🙌

This is a fix, for `OTEL_RESOURCE_ATTRIBUTES ` environment variable, as currently this env var will not be used which could lead to some confusion as other env vars work.

Background of this is, that in https://github.com/open-telemetry/opentelemetry-go/issues/1689 support for merging this resource variable was added, but it was moved in https://github.com/open-telemetry/opentelemetry-go/pull/2120#discussion_r676994234 to the `resource.New()` function.

Through using `resource.New()` we do not need to add additional command-line arguments but can leverage the merging behaviour. 