### PR TITLE
Set insecure on otelgrpc by default

### DIFF
--- a/otel.go
+++ b/otel.go
@@ -106,7 +106,7 @@ func OpenTelemetryRunE(flagPrefix string, prerunLevel zerolog.Level) CobraRunFun
 		case "otlpgrpc":
 			var opts []otlptracegrpc.Option
 			if endpoint != "" {
-				opts = append(opts, otlptracegrpc.WithEndpoint(endpoint))
+				opts = append(opts, otlptracegrpc.WithEndpoint(endpoint), otlptracegrpc.WithInsecure())
 			}
 
 			exporter, err = otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))


### PR DESCRIPTION
this matches the other collector config defaults

separately, we should support tls configuration for collectors