### PR TITLE
increase logging level for dotenv log message

### DIFF
--- a/cobrautil.go
+++ b/cobrautil.go
@@ -59,7 +59,7 @@ func SyncViperPreRunE(prefix string) CobraRunFunc {
 // The .dotenv file is loaded first before any additional Viper behavior.
 func SyncViperDotEnvPreRunE(prefix, envfilePath string, l logr.Logger) CobraRunFunc {
 	if err := godotenv.Load(stringz.DefaultEmpty(envfilePath, ".env")); err != nil {
-		l.Info(
+		l.V(2).Info(
 			"skipped loading dotenv",
 			"path", envfilePath,
 			"err", err,


### PR DESCRIPTION
this is called very early in programs using
cobrautil and was being logged with info level.

E.g. SpiceDB calls this multiple times during bootstrap and it becomes quite verbose