### PR TITLE
Remove undo behavior from maxprocs

### DIFF
--- a/cobraproclimits/cobraproclimits.go
+++ b/cobraproclimits/cobraproclimits.go
@@ -53,11 +53,10 @@ func SetProcLimitRunE() cobrautil.CobraRunFunc {
 	return func(cmd *cobra.Command, args []string) error {
 		logger := zerolog.DefaultContextLogger
 
-		undo, err := maxprocs.Set(maxprocs.Logger(zerolog.DefaultContextLogger.Printf))
+		_, err := maxprocs.Set(maxprocs.Logger(zerolog.DefaultContextLogger.Printf))
 		if err != nil {
 			logger.Fatal().Err(err).Msg("failed to set maxprocs")
 		}
-		defer undo()
 		return nil
 	}
 }


### PR DESCRIPTION
## Description
I'd somewhat naively copied this out of the `main.go` function that this was originally in, where calling `defer undo()` would have happened when that `main.go` entrypoint was unwound. When I moved it into this prerun function, that meant that when we exit the prerun it immediately undoes the set that it did. That's not very helpful. This fixes that.

## Notes
This does remove a behavior, in the sense that you now won't be able to call `undo`, but the assumption we're making is that you probably don't want to undo something that you're doing in a `PreRunE` anyway.

## Changes
* Remove undo behavior

## Testing
Review.